### PR TITLE
colorize pester output

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -138,9 +138,10 @@ jobs:
         run: |
           & .\Install-MsiLogged.ps1 -LiteralPath $env:MSIPATH1 -LogFile '${{ runner.temp }}\output.log'
 
-      - name: Test present
+      - name: Test present (self-upgrade)
         if: endsWith(matrix.mode, 'upgrade-self')
         run: |
+          . .\Initialize-Pester.ps1
           Invoke-Pester -Path MSI.Tests.ps1 -Tag Installed -Output Detailed
           Invoke-Pester -Path NTService.Tests.ps1 -Tag Present -Output Detailed
 
@@ -152,6 +153,7 @@ jobs:
       - name: Test present (upgraded)
         if: endsWith(matrix.mode, 'upgrade')
         run: |
+          . .\Initialize-Pester.ps1
           $c = New-PesterContainer -Path MSI.Tests.ps1 -Data @{
               ExpectedVersion = $env:BUILDVER2
           }
@@ -166,6 +168,7 @@ jobs:
       - name: Test absent
         if: endsWith(matrix.mode, 'reinstall')
         run: |
+          . .\Initialize-Pester.ps1
           Invoke-Pester -Path MSI.Tests.ps1 -Tag Absent -Output Detailed
           Invoke-Pester -Path NTService.Tests.ps1 -Tag Absent -Output Detailed
 
@@ -177,6 +180,7 @@ jobs:
       - name: Test present
         if: endsWith(matrix.mode, 'reinstall')
         run: |
+          . .\Initialize-Pester.ps1
           Invoke-Pester -Path MSI.Tests.ps1 -Tag Installed -Output Detailed
           Invoke-Pester -Path NTService.Tests.ps1 -Tag Present -Output Detailed
 

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -81,6 +81,16 @@ jobs:
     steps:
       - uses: actions/checkout@v3
 
+      # https://github.com/beatcracker/Powershell-Misc
+      # We want to use:
+      # - https://github.com/beatcracker/Powershell-Misc/blob/d0704cea3d1eb948f9720dc8826a630e86150c08/Write-Host.ps1
+      - name: PowerShell-Misc
+        uses: actions/checkout@v3
+        with:
+          repository: beatcracker/Powershell-Misc
+          ref: d0704cea3d1eb948f9720dc8826a630e86150c08
+          path: .powershell
+
       - name: Retrieve artifacts
         id: artifact
         uses: actions/download-artifact@v3
@@ -118,6 +128,7 @@ jobs:
       - name: Test present
         if: startsWith(matrix.mode, 'msi')
         run: |
+          . .\Initialize-Pester.ps1
           Invoke-Pester -Path MSI.Tests.ps1 -Tag Installed -Output Detailed
           Invoke-Pester -Path NTService.Tests.ps1 -Tag Present -Output Detailed
 

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -13,14 +13,13 @@ env:
   BUILDVER1: 0.0.99
   BUILDVER2: 0.0.100
 
-defaults:
-  run:
-    shell: cmd
-
 jobs:
   build:
     name: build
     runs-on: windows-2019
+    defaults:
+      run:
+        shell: cmd
     steps:
       - uses: actions/checkout@v3
 
@@ -75,6 +74,10 @@ jobs:
           - msi-reinstall
     env:
       INTEGRATION: .\test\integration
+    defaults:
+      run:
+        shell: pwsh
+        working-directory: ${{ env.INTEGRATION }}
     steps:
       - uses: actions/checkout@v3
 
@@ -93,7 +96,6 @@ jobs:
 
       - name: Set MSI names
         if: startsWith(matrix.mode, 'msi')
-        shell: pwsh
         run: |
           $fName = 'ccgvault_v{0}_x64.msi'
 
@@ -110,15 +112,11 @@ jobs:
 
       - name: Install from MSI
         if: startsWith(matrix.mode, 'msi')
-        working-directory: ${{ env.INTEGRATION }}
-        shell: pwsh
         run: |
           & .\Install-MsiLogged.ps1 -LiteralPath $env:MSIPATH1 -LogFile '${{ runner.temp }}\output.log'
 
       - name: Test present
         if: startsWith(matrix.mode, 'msi')
-        working-directory: ${{ env.INTEGRATION }}
-        shell: pwsh
         run: |
           Invoke-Pester -Path MSI.Tests.ps1 -Tag Installed -Output Detailed
           Invoke-Pester -Path NTService.Tests.ps1 -Tag Present -Output Detailed
@@ -126,30 +124,22 @@ jobs:
 
       - name: Upgrade self (install same version)
         if: endsWith(matrix.mode, 'upgrade-self')
-        working-directory: ${{ env.INTEGRATION }}
-        shell: pwsh
         run: |
           & .\Install-MsiLogged.ps1 -LiteralPath $env:MSIPATH1 -LogFile '${{ runner.temp }}\output.log'
 
       - name: Test present
         if: endsWith(matrix.mode, 'upgrade-self')
-        working-directory: ${{ env.INTEGRATION }}
-        shell: pwsh
         run: |
           Invoke-Pester -Path MSI.Tests.ps1 -Tag Installed -Output Detailed
           Invoke-Pester -Path NTService.Tests.ps1 -Tag Present -Output Detailed
 
       - name: Upgrade
         if: endsWith(matrix.mode, 'upgrade')
-        working-directory: ${{ env.INTEGRATION }}
-        shell: pwsh
         run: |
           & .\Install-MsiLogged.ps1 -LiteralPath $env:MSIPATH2 -LogFile '${{ runner.temp }}\output.log'
 
       - name: Test present (upgraded)
         if: endsWith(matrix.mode, 'upgrade')
-        working-directory: ${{ env.INTEGRATION }}
-        shell: pwsh
         run: |
           $c = New-PesterContainer -Path MSI.Tests.ps1 -Data @{
               ExpectedVersion = $env:BUILDVER2
@@ -159,36 +149,27 @@ jobs:
 
       - name: Uninstall
         if: endsWith(matrix.mode, 'reinstall')
-        working-directory: ${{ env.INTEGRATION }}
-        shell: pwsh
         run: |
           & .\Install-MsiLogged.ps1 -Mode X -LiteralPath $env:MSIPATH1 -LogFile '${{ runner.temp }}\output.log'
 
       - name: Test absent
         if: endsWith(matrix.mode, 'reinstall')
-        working-directory: ${{ env.INTEGRATION }}
-        shell: pwsh
         run: |
           Invoke-Pester -Path MSI.Tests.ps1 -Tag Absent -Output Detailed
           Invoke-Pester -Path NTService.Tests.ps1 -Tag Absent -Output Detailed
 
       - name: Reinstall
         if: endsWith(matrix.mode, 'reinstall')
-        working-directory: ${{ env.INTEGRATION }}
-        shell: pwsh
         run: |
           & .\Install-MsiLogged.ps1 -Mode I -LiteralPath $env:MSIPATH1 -LogFile '${{ runner.temp }}\output.log'
 
       - name: Test present
         if: endsWith(matrix.mode, 'reinstall')
-        working-directory: ${{ env.INTEGRATION }}
-        shell: pwsh
         run: |
           Invoke-Pester -Path MSI.Tests.ps1 -Tag Installed -Output Detailed
           Invoke-Pester -Path NTService.Tests.ps1 -Tag Present -Output Detailed
 
       - name: Set bin location
-        shell: pwsh
         run: |
           $path = if ('${{ matrix.mode }}'.StartsWith('msi')) {
               $env:ProgramFiles | Join-Path -ChildPath 'CcgVault'
@@ -200,5 +181,6 @@ jobs:
           echo "CcgVaultBin=${path}" >> $env:GITHUB_ENV
 
       - name: Run simple help
+        shell: cmd
         working-directory: ${{ env.CcgVaultBin }}
         run: CcgVault.exe --help

--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 /.vscode
+/.powershell
 testResults.xml
 
 ## Ignore Visual Studio temporary files, build results, and

--- a/test/integration/Initialize-Pester.ps1
+++ b/test/integration/Initialize-Pester.ps1
@@ -1,0 +1,17 @@
+# https://github.com/pester/Pester/issues/1953#issuecomment-1101705143
+#
+# We're just looking to override an internal function to get ANSI colors in CI.
+# Once the capability is available natively in Pester we'll bump our minimum
+# and remove this.
+
+$pester = Import-Module -Name Pester -MinimumVersion 5.2.0 -Force -PassThru -ErrorAction Stop
+
+$pester.Invoke({
+    $file = "$PSScriptRoot/../.." |
+        Resolve-Path |
+        Join-Path -ChildPath .powershell/Write-Host.ps1
+
+    . $file
+
+    $SafeCommands['Write-Host'] = Get-Command -Type Function -Name Write-Host
+})


### PR DESCRIPTION
https://github.com/pester/Pester/issues/1953

We're just looking to override an internal function to get ANSI colors in CI. Once the capability is available natively in Pester we'll bump our minimum and remove this.

Hat tip to @beatcracker and @fflaten for the help 😃 

