### PR TITLE
Ensure the installer enabled the plugin in the CCG

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -74,6 +74,7 @@ jobs:
           - msi-reinstall
     env:
       INTEGRATION: .\test\integration
+      CCG_BUILD_VER: ${{ env.BUILDVER1 }}
     defaults:
       run:
         shell: pwsh
@@ -154,12 +155,11 @@ jobs:
 
       - name: Test present (upgraded)
         if: endsWith(matrix.mode, 'upgrade')
+        env:
+          CCG_BUILD_VER: ${{ env.BUILDVER2 }}
         run: |
           . .\Initialize-Pester.ps1
-          $c = New-PesterContainer -Path *.Tests.ps1 -Data @{
-              ExpectedVersion = $env:BUILDVER2
-          }
-          Invoke-Pester -Container $c -Tag Present -Output Detailed
+          Invoke-Pester -Tag Present -Output Detailed
 
       - name: Uninstall
         if: endsWith(matrix.mode, 'reinstall')

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -98,7 +98,6 @@ jobs:
           path: .artifact
 
       - name: Install PowerShell modules
-        if: startsWith(matrix.mode, 'msi')
         uses: potatoqualitee/psmodulecache@v4.5
         with:
           modules-to-cache: MSI:3.3.4

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -10,6 +10,7 @@ on:
 env:
   SOLUTION: src\CcgVault.sln
   RELEASE: src\CcgVault\bin\Release
+  CCG_BUILD_VER: 0.0.99
   BUILDVER1: 0.0.99
   BUILDVER2: 0.0.100
 
@@ -74,7 +75,6 @@ jobs:
           - msi-reinstall
     env:
       INTEGRATION: .\test\integration
-      CCG_BUILD_VER: ${{ env.BUILDVER1 }}
     defaults:
       run:
         shell: pwsh

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -203,4 +203,4 @@ jobs:
         if: matrix.mode == 'bin'
         shell: cmd
         working-directory: ${{ env.CcgVaultBin }}
-        run: CcgVault.exe --permission --comclass
+        run: CcgVault.exe registry --permission --comclass

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -120,18 +120,21 @@ jobs:
               echo "MSIPATH${i}=$path" >> $env:GITHUB_ENV
           }
 
+      - name: Test absent (pre-run)
+        run: |
+          . .\Initialize-Pester.ps1
+          Invoke-Pester -Tag Absent -Output Detailed
+
       - name: Install from MSI
         if: startsWith(matrix.mode, 'msi')
         run: |
           & .\Install-MsiLogged.ps1 -LiteralPath $env:MSIPATH1 -LogFile '${{ runner.temp }}\output.log'
 
-      - name: Test present
+      - name: Test present (install)
         if: startsWith(matrix.mode, 'msi')
         run: |
           . .\Initialize-Pester.ps1
-          Invoke-Pester -Path MSI.Tests.ps1 -Tag Installed -Output Detailed
-          Invoke-Pester -Path COMPlus.Tests.ps1 -Tag Present -Output Detailed
-          Invoke-Pester -Path NTService.Tests.ps1 -Tag Present -Output Detailed
+          Invoke-Pester -Tag Present -Output Detailed
 
 
       - name: Upgrade self (install same version)
@@ -143,9 +146,7 @@ jobs:
         if: endsWith(matrix.mode, 'upgrade-self')
         run: |
           . .\Initialize-Pester.ps1
-          Invoke-Pester -Path MSI.Tests.ps1 -Tag Installed -Output Detailed
-          Invoke-Pester -Path COMPlus.Tests.ps1 -Tag Present -Output Detailed
-          Invoke-Pester -Path NTService.Tests.ps1 -Tag Present -Output Detailed
+          Invoke-Pester -Tag Present -Output Detailed
 
       - name: Upgrade
         if: endsWith(matrix.mode, 'upgrade')
@@ -156,25 +157,21 @@ jobs:
         if: endsWith(matrix.mode, 'upgrade')
         run: |
           . .\Initialize-Pester.ps1
-          $c = New-PesterContainer -Path MSI.Tests.ps1 -Data @{
+          $c = New-PesterContainer -Path *.Tests.ps1 -Data @{
               ExpectedVersion = $env:BUILDVER2
           }
-          Invoke-Pester -Container $c -Tag Installed -Output Detailed
-          Invoke-Pester -Path COMPlus.Tests.ps1 -Tag Present -Output Detailed
-          Invoke-Pester -Path NTService.Tests.ps1 -Tag Present -Output Detailed
+          Invoke-Pester -Container $c -Tag Present -Output Detailed
 
       - name: Uninstall
         if: endsWith(matrix.mode, 'reinstall')
         run: |
           & .\Install-MsiLogged.ps1 -Mode X -LiteralPath $env:MSIPATH1 -LogFile '${{ runner.temp }}\output.log'
 
-      - name: Test absent
+      - name: Test absent (uninstall)
         if: endsWith(matrix.mode, 'reinstall')
         run: |
           . .\Initialize-Pester.ps1
-          Invoke-Pester -Path MSI.Tests.ps1 -Tag Absent -Output Detailed
-          Invoke-Pester -Path COMPlus.Tests.ps1 -Tag Absent -Output Detailed
-          Invoke-Pester -Path NTService.Tests.ps1 -Tag Absent -Output Detailed
+          Invoke-Pester -Tag Absent -Output Detailed
 
       - name: Reinstall
         if: endsWith(matrix.mode, 'reinstall')
@@ -185,9 +182,7 @@ jobs:
         if: endsWith(matrix.mode, 'reinstall')
         run: |
           . .\Initialize-Pester.ps1
-          Invoke-Pester -Path MSI.Tests.ps1 -Tag Installed -Output Detailed
-          Invoke-Pester -Path COMPlus.Tests.ps1 -Tag Present -Output Detailed
-          Invoke-Pester -Path NTService.Tests.ps1 -Tag Present -Output Detailed
+          Invoke-Pester -Tag Present -Output Detailed
 
       - name: Set bin location
         run: |

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -198,3 +198,9 @@ jobs:
         shell: cmd
         working-directory: ${{ env.CcgVaultBin }}
         run: CcgVault.exe --help
+
+      - name: Set reg
+        if: matrix.mode == 'bin'
+        shell: cmd
+        working-directory: ${{ env.CcgVaultBin }}
+        run: CcgVault.exe --permission --comclass

--- a/msi/src/CcgVault.wxs
+++ b/msi/src/CcgVault.wxs
@@ -6,6 +6,14 @@
         <Media Id="1" Cabinet="CcgVault.cab" EmbedCab="yes" />
 
         <Directory Id="TARGETDIR" Name="SourceDir">
+            <Component Id="CcgRegistry" Guid="9A8F266A-FDDB-4740-B389-FFF9DC533CDB">
+                <RegistryKey
+                    Root="HKLM"
+                    Key="SYSTEM\CurrentControlSet\Control\CCG\COMClasses\{01BF101D-BFB6-433F-B416-02885CDC5AD3}"
+                    Action="createAndRemoveOnUninstall"
+                    ForceCreateOnInstall="yes"
+                />
+            </Component>
             <Directory Id="ProgramFiles64Folder">
                 <Directory Id="APPLICATIONROOTDIRECTORY" Name="CcgVault">
                     <Component Id="CcgVault.exe" Guid="8A3DDC03-DA64-407A-8B11-7A241DE0564F">

--- a/msi/src/CcgVault.wxs
+++ b/msi/src/CcgVault.wxs
@@ -36,6 +36,7 @@
             <ComponentRef Id="CcgVault.exe" />
             <ComponentGroupRef Id="CoGr" />
             <ComponentGroupRef Id="CoComPlus" />
+            <ComponentRef Id="CcgRegistry" />
         </Feature>
 
         <InstallExecuteSequence>

--- a/msi/src/CcgVault.wxs
+++ b/msi/src/CcgVault.wxs
@@ -48,6 +48,9 @@
             <Custom Action="ServiceCreate" After="ImplicitRegister">
                 NOT REMOVE
             </Custom>
+            <Custom Action="CcgRegistryAction" After="ServiceCreate">
+                NOT REMOVE
+            </Custom>
         </InstallExecuteSequence>
     </Product>
 </Wix>

--- a/msi/src/ComPlus.wxs
+++ b/msi/src/ComPlus.wxs
@@ -41,7 +41,7 @@
                         FileKey="CcgVault.exe"
                         Execute="commit"
                         Impersonate="no"
-                        ExeCommand="[CcgVault.exe] registry --permissions --comclass"
+                        ExeCommand="[CcgVault.exe] registry --permission --comclass"
                         Return="check"
          />
     </Fragment>

--- a/msi/src/ComPlus.wxs
+++ b/msi/src/ComPlus.wxs
@@ -33,6 +33,17 @@
                         ExeCommand="[CcgVault.exe] service --install"
                         Return="check"
         />
+        <!--
+            Microsoft Installer will not modify registry keys owned by TrustedInstaller
+            so we need a custom action to do this.
+         -->
+         <CustomAction  Id="CcgRegistryAction"
+                        FileKey="CcgVault.exe"
+                        Execute="commit"
+                        Impersonate="no"
+                        ExeCommand="[CcgVault.exe] registry --permissions --comclass"
+                        Return="check"
+         />
     </Fragment>
     <Fragment>
         <ComponentGroup Id="CoComPlus">

--- a/src/CcgVault/CcgVault.csproj
+++ b/src/CcgVault/CcgVault.csproj
@@ -82,6 +82,7 @@
   <ItemGroup>
     <Compile Include="AuthType.cs" />
     <Compile Include="CcgPlugin.cs" />
+    <Compile Include="TokenPrivilege.cs" />
     <Compile Include="Config.cs" />
     <Compile Include="BackendType.cs" />
     <Compile Include="KV2BackendType .cs" />

--- a/src/CcgVault/Program.cs
+++ b/src/CcgVault/Program.cs
@@ -102,7 +102,7 @@ namespace CcgVault
                 {
                     using (new TokenPrivilege(TokenPrivilege.SE_TAKE_OWNERSHIP_NAME, TokenPrivilege.SE_RESTORE_NAME))
                     { 
-                        key = Registry.LocalMachine.OpenSubKey(subkey, RegistryKeyPermissionCheck.ReadWriteSubTree, System.Security.AccessControl.RegistryRights.TakeOwnership);
+                        key = Registry.LocalMachine.OpenSubKey(subkey, RegistryKeyPermissionCheck.ReadWriteSubTree, RegistryRights.TakeOwnership);
 
                         if (key == null)
                         {
@@ -127,15 +127,15 @@ namespace CcgVault
                         key.SetAccessControl(ac);
                         key.Close();
                     }
+                }
 
-                    if (ComClass)
-                    {
-                        var pluginId = (GuidAttribute)Attribute.GetCustomAttribute(typeof(CcgPlugin), typeof(GuidAttribute), true);
+                if (ComClass)
+                {
+                    var pluginId = (GuidAttribute)Attribute.GetCustomAttribute(typeof(CcgPlugin), typeof(GuidAttribute), true);
 
-                        key = Registry.LocalMachine.OpenSubKey(subkey, RegistryKeyPermissionCheck.ReadWriteSubTree);
-                        key.CreateSubKey($"{{{pluginId.Value}}}");
-                        key.Close();
-                    }
+                    key = Registry.LocalMachine.OpenSubKey(subkey, RegistryKeyPermissionCheck.ReadWriteSubTree);
+                    key.CreateSubKey($"{{{pluginId.Value}}}");
+                    key.Close();
                 }
             }
         }

--- a/src/CcgVault/Program.cs
+++ b/src/CcgVault/Program.cs
@@ -1,11 +1,14 @@
 using COMAdmin;
 using Fclp;
+using Microsoft.Win32;
 using System;
 using System.Diagnostics;
 using System.EnterpriseServices;
 using System.Linq;
 using System.Reflection;
 using System.Runtime.InteropServices;
+using System.Security.AccessControl;
+using System.Security.Principal;
 
 namespace CcgVault
 {
@@ -63,6 +66,76 @@ namespace CcgVault
                 {
                     Console.WriteLine("Expecting response: 'Pong'");
                     Console.WriteLine($"Got response: '{ccg.Ping()}'");
+                }
+            }
+        }
+
+        class CliCommandRegistry : ICliCommand
+        {
+            public bool Permission { get; set; }
+            public bool ComClass { get; set; }
+
+            public void Help(string text)
+            {
+                Console.WriteLine("ccgvault.exe registry");
+                Console.WriteLine();
+                Console.WriteLine(@"Adds the CcgVault CLSID to the allowed CCG plugins and/or sets permission and ownership of the CCG\COMClasses key.");
+                Console.WriteLine();
+                Console.WriteLine("The following options are accepted:");
+                Console.WriteLine(text);
+                Exit(-1);
+            }
+
+            public void Invoke()
+            {
+                var subkey = @"SYSTEM\CurrentControlSet\Control\CCG\COMClasses";
+
+                if (!(Permission || ComClass))
+                {
+                    Console.WriteLine("Neither --permission nor --comclass were specified. Choose one or both.");
+                    Exit(-1);
+                }
+
+                RegistryKey key;
+
+                if (Permission)
+                {
+                    using (new TokenPrivilege(TokenPrivilege.SE_TAKE_OWNERSHIP_NAME, TokenPrivilege.SE_RESTORE_NAME))
+                    { 
+                        key = Registry.LocalMachine.OpenSubKey(subkey, RegistryKeyPermissionCheck.ReadWriteSubTree, System.Security.AccessControl.RegistryRights.TakeOwnership);
+
+                        if (key == null)
+                        {
+                            Console.WriteLine($"{subkey} not found or error opening key.");
+                            Exit(-1);
+                        }
+
+                        const string SID_ADMINISTRATORS = "S-1-5-32-544";
+                        var admins = new SecurityIdentifier(SID_ADMINISTRATORS).Translate(typeof(NTAccount));
+                        var ac = key.GetAccessControl();
+                        ac.SetOwner(admins);
+                        key.SetAccessControl(ac);
+                        key.Close();
+
+                        key = Registry.LocalMachine.OpenSubKey(subkey, RegistryKeyPermissionCheck.ReadWriteSubTree, RegistryRights.TakeOwnership);
+                        ac = key.GetAccessControl();
+                        ac.AddAccessRule(new RegistryAccessRule(admins,
+                            RegistryRights.FullControl,
+                            InheritanceFlags.ContainerInherit | InheritanceFlags.ObjectInherit,
+                            PropagationFlags.None,
+                            AccessControlType.Allow));
+                        key.SetAccessControl(ac);
+                        key.Close();
+                    }
+
+                    if (ComClass)
+                    {
+                        var pluginId = (GuidAttribute)Attribute.GetCustomAttribute(typeof(CcgPlugin), typeof(GuidAttribute), true);
+
+                        key = Registry.LocalMachine.OpenSubKey(subkey, RegistryKeyPermissionCheck.ReadWriteSubTree);
+                        key.CreateSubKey($"{{{pluginId.Value}}}");
+                        key.Close();
+                    }
                 }
             }
         }
@@ -213,6 +286,23 @@ namespace CcgVault
                     Exit(0);
                     return;
 
+                case "registry":
+                    var _registry = new FluentCommandLineParser<CliCommandRegistry>();
+
+                    _registry.SetupHelp("?", "help")
+                        .Callback(text => _registry.Object.Help(text));
+
+                    _registry.Setup<bool>(arg => arg.Permission)
+                        .As('p', "permission");
+
+                    _registry.Setup<bool>(arg => arg.ComClass)
+                        .As('c', "comclass");
+
+                    result = _registry.Parse(arguments);
+                    command = _registry.Object;
+
+                    break;
+
                 case "help":
                 case "":
                 default:
@@ -222,6 +312,8 @@ namespace CcgVault
                     Console.WriteLine("test");
                     Console.WriteLine("ping");
                     Console.WriteLine("service");
+                    Console.WriteLine("terminate");
+                    Console.WriteLine("registry");
                     Exit(0);
                     return;
             }

--- a/src/CcgVault/TokenPrivilege.cs
+++ b/src/CcgVault/TokenPrivilege.cs
@@ -1,0 +1,127 @@
+using System;
+using System.Collections.Generic;
+using System.ComponentModel;
+using System.Runtime.InteropServices;
+
+namespace CcgVault
+{
+    class TokenPrivilege : IDisposable
+    {
+        [DllImport("advapi32.dll", ExactSpelling = true, SetLastError = true)]
+        internal static extern bool AdjustTokenPrivileges(IntPtr htok, bool disall,
+        ref TokPriv1Luid newst, int len, IntPtr prev, IntPtr relen);
+
+
+        [DllImport("kernel32.dll", ExactSpelling = true)]
+        internal static extern IntPtr GetCurrentProcess();
+
+
+        [DllImport("advapi32.dll", ExactSpelling = true, SetLastError = true)]
+        internal static extern bool OpenProcessToken(IntPtr h, int acc, ref IntPtr
+        phtok);
+
+
+        [DllImport("kernel32.dll", ExactSpelling = true, SetLastError = true)]
+        internal static extern bool CloseHandle(IntPtr hObject);
+
+
+        [DllImport("advapi32.dll", SetLastError = true)]
+        internal static extern bool LookupPrivilegeValue(string host, string name,
+        ref long pluid);
+
+
+        [StructLayout(LayoutKind.Sequential, Pack = 1)]
+        internal struct TokPriv1Luid
+        {
+            public const int Count = 1;
+            public long Luid;
+            public int Attr;
+
+            public TokPriv1Luid(string privilege, int attributes = SE_PRIVILEGE_ENABLED)
+            {
+                Attr = attributes;
+                Luid = 0;
+                LookupPrivilegeValue(null, privilege, ref Luid);
+            }
+        }
+
+        internal const int SE_PRIVILEGE_DISABLED = 0x00000000;
+        internal const int SE_PRIVILEGE_ENABLED = 0x00000002;
+        internal const int TOKEN_QUERY = 0x00000008;
+        internal const int TOKEN_ADJUST_PRIVILEGES = 0x00000020;
+
+        public const string SE_ASSIGNPRIMARYTOKEN_NAME = "SeAssignPrimaryTokenPrivilege";
+        public const string SE_AUDIT_NAME = "SeAuditPrivilege";
+        public const string SE_BACKUP_NAME = "SeBackupPrivilege";
+        public const string SE_CHANGE_NOTIFY_NAME = "SeChangeNotifyPrivilege";
+        public const string SE_CREATE_GLOBAL_NAME = "SeCreateGlobalPrivilege";
+        public const string SE_CREATE_PAGEFILE_NAME = "SeCreatePagefilePrivilege";
+        public const string SE_CREATE_PERMANENT_NAME = "SeCreatePermanentPrivilege";
+        public const string SE_CREATE_SYMBOLIC_LINK_NAME = "SeCreateSymbolicLinkPrivilege";
+        public const string SE_CREATE_TOKEN_NAME = "SeCreateTokenPrivilege";
+        public const string SE_DEBUG_NAME = "SeDebugPrivilege";
+        public const string SE_ENABLE_DELEGATION_NAME = "SeEnableDelegationPrivilege";
+        public const string SE_IMPERSONATE_NAME = "SeImpersonatePrivilege";
+        public const string SE_INC_BASE_PRIORITY_NAME = "SeIncreaseBasePriorityPrivilege";
+        public const string SE_INCREASE_QUOTA_NAME = "SeIncreaseQuotaPrivilege";
+        public const string SE_INC_WORKING_SET_NAME = "SeIncreaseWorkingSetPrivilege";
+        public const string SE_LOAD_DRIVER_NAME = "SeLoadDriverPrivilege";
+        public const string SE_LOCK_MEMORY_NAME = "SeLockMemoryPrivilege";
+        public const string SE_MACHINE_ACCOUNT_NAME = "SeMachineAccountPrivilege";
+        public const string SE_MANAGE_VOLUME_NAME = "SeManageVolumePrivilege";
+        public const string SE_PROF_SINGLE_PROCESS_NAME = "SeProfileSingleProcessPrivilege";
+        public const string SE_RELABEL_NAME = "SeRelabelPrivilege";
+        public const string SE_REMOTE_SHUTDOWN_NAME = "SeRemoteShutdownPrivilege";
+        public const string SE_RESTORE_NAME = "SeRestorePrivilege";
+        public const string SE_SECURITY_NAME = "SeSecurityPrivilege";
+        public const string SE_SHUTDOWN_NAME = "SeShutdownPrivilege";
+        public const string SE_SYNC_AGENT_NAME = "SeSyncAgentPrivilege";
+        public const string SE_SYSTEM_ENVIRONMENT_NAME = "SeSystemEnvironmentPrivilege";
+        public const string SE_SYSTEM_PROFILE_NAME = "SeSystemProfilePrivilege";
+        public const string SE_SYSTEMTIME_NAME = "SeSystemtimePrivilege";
+        public const string SE_TAKE_OWNERSHIP_NAME = "SeTakeOwnershipPrivilege";
+        public const string SE_TCB_NAME = "SeTcbPrivilege";
+        public const string SE_TIME_ZONE_NAME = "SeTimeZonePrivilege";
+        public const string SE_TRUSTED_CREDMAN_ACCESS_NAME = "SeTrustedCredManAccessPrivilege";
+        public const string SE_UNDOCK_NAME = "SeUndockPrivilege";
+        public const string SE_UNSOLICITED_INPUT_NAME = "SeUnsolicitedInputPrivilege";
+
+        internal IntPtr hProcess = GetCurrentProcess();
+        internal IntPtr hToken;
+        internal Stack<TokPriv1Luid> privsToDisable;
+
+        public TokenPrivilege(params string[] privileges)
+        {
+            privsToDisable = new Stack<TokPriv1Luid>(privileges.Length);
+
+            OpenProcessToken(hProcess, TOKEN_ADJUST_PRIVILEGES | TOKEN_QUERY, ref hToken);
+            foreach (string privilege in privileges)
+            {
+                var tokenPrivilege = new TokPriv1Luid(privilege);
+                bool success = AdjustTokenPrivileges(hToken, false, ref tokenPrivilege, 0, IntPtr.Zero, IntPtr.Zero);
+                if (success)
+                {
+                    privsToDisable.Push(tokenPrivilege);
+                }
+                else
+                {
+                    int e = Marshal.GetLastWin32Error();
+                    string msg = $"Error adjusting token privilege '{privilege}'.";
+                    var ex = new Win32Exception(e);
+                    throw new InvalidOperationException(msg, ex);
+                }
+            }
+        }
+
+        public void Dispose()
+        {
+            while (privsToDisable.Count > 0)
+            {
+                var tokenPrivilege = privsToDisable.Pop();
+                tokenPrivilege.Attr = SE_PRIVILEGE_DISABLED;
+                AdjustTokenPrivileges(hToken, false, ref tokenPrivilege, 0, IntPtr.Zero, IntPtr.Zero);
+            }
+            CloseHandle(hToken);
+        }        
+    }
+}

--- a/src/CcgVault/TokenPrivilege.cs
+++ b/src/CcgVault/TokenPrivilege.cs
@@ -34,7 +34,7 @@ namespace CcgVault
         [StructLayout(LayoutKind.Sequential, Pack = 1)]
         internal struct TokPriv1Luid
         {
-            public int Count;
+            public readonly int Count;
             public long Luid;
             public int Attr;
 

--- a/test/integration/MSI.Tests.ps1
+++ b/test/integration/MSI.Tests.ps1
@@ -13,7 +13,7 @@ param(
 
     [Parameter()]
     [System.Version]
-    $ExpectedVersion = $env:BUILDVER1
+    $ExpectedVersion = $env:CCG_BUILD_VER
 )
 
 BeforeAll {

--- a/test/integration/MSI.Tests.ps1
+++ b/test/integration/MSI.Tests.ps1
@@ -28,7 +28,7 @@ BeforeAll {
 }
 
 Describe 'MSI tests' {
-    Context 'Installed' -Tag Installed {
+    Context 'Present' -Tag Present {
         It '<Name> is installed' {
             $msi | Should -Not -BeNullOrEmpty
         }

--- a/test/integration/Registry.Tests.ps1
+++ b/test/integration/Registry.Tests.ps1
@@ -1,0 +1,23 @@
+#Requires -Module @{ ModuleName = 'Pester'; ModuleVersion = '5.2.0' }
+
+BeforeAll {
+    $data = Import-PowerShellDataFile -LiteralPath $PSScriptRoot\TestData.psd1
+
+    $ccgPluginId = [Guid]::Parse($data.ComPlus.CcgPlugin.ID)
+
+    $Script:path = $data.Registry.Path | Join-Path -ChildPath $ccgPluginId.ToString('B')
+}
+
+Describe 'Registry tests' {
+    Context 'Present' -Tag Present {
+        It 'Plugin CLSID is enabled for CCG use' {
+            Test-Path -LiteralPath $path | Should -BeTrue
+        }
+    }
+
+    Context 'Absent' -Tag Absent {
+        It 'Plugin CLSID is not enabled for CCG use' {
+            Test-Path -LiteralPath $path | Should -Not -BeTrue
+        }
+    }
+}

--- a/test/integration/TestData.psd1
+++ b/test/integration/TestData.psd1
@@ -12,4 +12,8 @@
         StartMode = 'Manual'
         Executable = 'dllhost.exe'
     }
+
+    Registry = @{
+        Path = 'HKLM:\SYSTEM\CurrentControlSet\Control\CCG\COMClasses'
+    }
 }


### PR DESCRIPTION
Currently the installer doesn't set this up, and the registry key is annoying to change because you need to reset its permissions to do so; that makes it ideal for the installer to handle.

[Setting the registry key is described here](https://docs.microsoft.com/en-us/windows/win32/api/ccgplugins/nf-ccgplugins-iccgdomainauthcredentials-getpasswordcredentials#remarks). Note that the path shown there is incorrect:
- https://github.com/MicrosoftDocs/sdk-api/pull/1006
